### PR TITLE
links-only parameter, and drop items in a new photobucket/ folder in the pwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ optional arguments:
                         sources.
   -o OUTPUT_DIRECTORY, --output-directory OUTPUT_DIRECTORY
                         The directory the extracted images getting saved in.
+                        Default: `photobucket/` in current working directory
   --omit-existing
   -v VERBOSE, --verbose VERBOSE
   -f FILE, --file FILE  A file containing one or more Photobucket links which

--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ Example
 Download a single image to the default `./photobucket/` directory:
 
 ```
-python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/media/Internet Fads/b217a64d.gif.html'
+python pb_shovel.py -u 'http://s160.photobucket.com/user/Spinningfox/media/Internet Fads/b217a64d.gif.html'
 ```
 
 Obtain all the urls of a Photobucket Album, even subalbums, and put them in `links-<datetime>.txt`. This url file can be given to `wget` (just download all images) or [grab-site](https://github.com/ludios/grab-site) (archive all links as WARC).
 
 ```
-python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/library/Internet Fads' -r --links-only
-wget -i links-2016-03-20_02-03-01.txt
-grab-site -i links-2016-03-20_02-03-01.txt
+python pb_shovel.py -u 'http://s160.photobucket.com/user/Spinningfox/library/Internet Fads' -r --links-only
+wget -i links-2016-03-20_02-03-01.txt # or you can use curl
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Download a single image to the default `./photobucket/` directory:
 python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/media/Internet Fads/b217a64d.gif.html'
 ```
 
-Obtain all the urls of a Photobucket Album, even subalbums, and put them in `links-<datetime>.txt`. Don't download (this url file can be given to `wget` or `grab-site`)
+Obtain all the urls of a Photobucket Album, even subalbums, and put them in `links-<datetime>.txt`. This url file can be given to `wget` (just download all images) or [grab-site](https://github.com/ludios/grab-site) (archive all links as WARC).
 
 ```
 python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/library/Internet Fads' -r --links-only
+wget -i links-2016-03-20_02-03-01.txt
+grab-site -i links-2016-03-20_02-03-01.txt
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ optional arguments:
                         which is hosted on Photobucket.
   --images-only         Do not download any other filetype besides image.
   --videos-only         Do not download any other filetype besides video.
+  --links-only          Only store the links to the images in a text file: links-<datetime>.txt
 
 Authentication:
   -n USERNAME, --username USERNAME
@@ -32,6 +33,22 @@ Authentication:
                         The matching password for your account.
 
 ```
+
+Recursive Album Downloads
+=========================
+
+If you're an archivist, you would obviously want to download all nested folders in the current
+album. This script supports this feature: just add `-r` to download these nested folders. Done.
+
+Extracting URLs
+===============
+
+The `--links-only` parameter can be used to store all the image URLs in a text file:
+
+`links-<datetime>.txt`
+
+This file can then be passed into `wget`, `wpull`, or `grab-site` to archive the 
+images to a sane directory structure, or to to WARC format.
 
 Guest password
 =====================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+Example
+=======
+
+Download a single image to the default `./photobucket/` directory:
+
+```
+python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/media/Internet Fads/b217a64d.gif.html'
+```
+
+Obtain all the urls of a Photobucket Album, even subalbums, and put them in `links-<datetime>.txt`. Don't download (this url file can be given to `wget` or `grab-site`)
+
+```
+python pb_shovel.py 'http://s160.photobucket.com/user/Spinningfox/library/Internet Fads' -r --links-only
+```
+
 Usage
 =====
 

--- a/pb_shovel.py
+++ b/pb_shovel.py
@@ -241,7 +241,7 @@ class Photobucket():
         if not out:
             # Define the present working directory if it wasn't passed explicitly
             # with the -o/--output-directory argument.
-            out = os.getcwd()
+            out = os.path.join(os.getcwd(), 'photobucket')
         elif out.startswith("~"):
             # Resolve the tilde char (which is the home directory on *nix) to
             # it's actual destination.


### PR DESCRIPTION
## Write inside a folder by default rather than pwd

It's inconvenient to have the script drop everything into your current working directory, which just makes a mess. 

Instead, by default, a photobucket folder in the current working directory should be created. This way the folder can be moved around or rm'ed easily.

## Links-only parameter to list out all image urls, not download

Sometimes I want to use an external application such as grab-site or wget to archive the URLs instead (this way I can get a full directory structure or put everything into WARCS).

Thus, I have added a links-only parameter to list out the urls into a file instead of downloading.